### PR TITLE
Drop uneeded runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
     "url": "https://github.com/benjycui/omit.js/issues"
   },
   "homepage": "https://github.com/benjycui/omit.js#readme",
-  "dependencies": {
-    "babel-runtime": "^6.23.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "assert": "^1.4.1",
     "rc-test": "^6.0.7",


### PR DESCRIPTION
Since the actual implementation is not using it, it looks like
`babel-runtime` can be safely dropped as a runtime dependency.